### PR TITLE
Task/8015 8017 list linux ports and exceptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,20 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package serial
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for forked serial
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.2.3 (2025-01-02)
+------------------
+* (8017) Changed the linux serial port listing to include more device names
+* (8015) Removed the __file__ and __line__ macros from exception messages
+
 1.2.2 (2024-12-17)
 ------------------
 * Replaced catkin build system with cmake
 * Fixed minor warnings related to unused variables and comparing unsigned and signed integers
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package serial (original)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1.2.1 (2015-04-21)
 ------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@
 
 cmake_minimum_required(VERSION 3.27)
 
+option(BUILD_EXAMPLE "Build example executable" OFF)
+
 project(wjwwood-serial
-    VERSION 1.2.2
+    VERSION 1.2.3
     LANGUAGES CXX
 )
 
@@ -80,6 +82,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 set_target_properties(${PROJECT_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+if (BUILD_EXAMPLE)
+    add_subdirectory(examples)
+endif()
 
 # Install the library
 install(TARGETS ${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 **CUSTOM FORK NOTE**
+
+_2025-02-25 Update_
+Functionality to list ports are upgraded to gather more ports than initially possible.
+
+_Initial release_
 This fork does not change any functionality of the original code. Changes applied are:
 - Replaced usage of catkin build system in favor of cmake
 - Cleaned build warnings for linux and windows builds
@@ -24,11 +29,7 @@ API Documentation: http://wjwwood.github.io/serial/doc/1.1.0/index.html
 ### Dependencies
 
 Required:
-* [catkin](http://www.ros.org/wiki/catkin) - cmake and Python based buildsystem
 * [cmake](http://www.cmake.org) - buildsystem
-* [Python](http://www.python.org) - scripting language
-  * [empy](http://www.alcyone.com/pyos/empy/) - Python templating library
-  * [catkin_pkg](http://pypi.python.org/pypi/catkin_pkg/) - Runtime Python library for catkin
 
 Optional (for documentation):
 * [Doxygen](http://www.doxygen.org/) - Documentation generation tool
@@ -38,23 +39,25 @@ Optional (for documentation):
 
 Get the code:
 
-    git clone https://github.com/wjwwood/serial.git
+    git clone https://github.com/EelumeAS/wjwwood-serial.git
+
+Configure:
+
+    With example application:
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLE=ON
+
+    Without example application:
+    cmake -DCMAKE_BUILD_TYPE=Release
 
 Build:
 
-    make
-
-Build and run the tests:
-
-    make test
-
-Build the documentation:
-
-    make doc
+    Windows: cmake --build . --config Release
+    Linux: make -j16
 
 Install:
 
-    make install
+    Windows cmake --install .
+    Linux: make install
 
 ### License
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Minimum viable CMakeLists.txt file for compiling and installing the serialport library using cmake.
+
+cmake_minimum_required(VERSION 3.27)
+
+# Define output locations for the library
+include(GNUInstallDirs)
+if(UNIX)
+    option(BUILD_SHARED_LIBS "Build shared libraries(.so)." ON)
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+    # for multi-config build system (e.g. Xcode, ninja Multi-Config)
+    foreach(OUTPUTCONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
+        string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/lib)
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/lib)
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${CMAKE_INSTALL_BINDIR})
+    endforeach()
+
+elseif(MSVC)
+    # Build static library for Windows
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR})
+    foreach(OUTPUTCONFIG IN LISTS CMAKE_CONFIGURATION_TYPES)
+        string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG)
+        set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${CMAKE_INSTALL_BINDIR})
+        set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${CMAKE_INSTALL_BINDIR})
+        set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${CMAKE_BINARY_DIR}/${OUTPUTCONFIG}/${CMAKE_INSTALL_BINDIR})
+    endforeach()
+endif()
+
+# Add the library
+file(GLOB_RECURSE SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.cc)
+file(GLOB_RECURSE HEADERS ${CMAKE_CURRENT_LIST_DIR}/*.h)
+
+set(TARGET_NAME "wjwwood-serial-example")
+
+add_executable(${TARGET_NAME}
+    ${SOURCES}
+    ${HEADERS}
+)
+
+target_link_libraries(${TARGET_NAME} PRIVATE ${PROJECT_NAME})
+
+# Include directories
+target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+target_compile_features(${TARGET_NAME} PRIVATE cxx_std_17)

--- a/include/serial/serial.h
+++ b/include/serial/serial.h
@@ -706,15 +706,13 @@ public:
 #else
       char * error_str = strerror(errnum);
 #endif
-      ss << "IO Exception (" << errno_ << "): " << error_str;
-      ss << ", file " << file_ << ", line " << line_ << ".";
+      ss << "IO Exception (" << errno_ << "): " << error_str << ".";
       e_what_ = ss.str();
   }
   explicit IOException (std::string file, int line, const char * description)
     : file_(file), line_(line), errno_(0) {
       std::stringstream ss;
-      ss << "IO Exception: " << description;
-      ss << ", file " << file_ << ", line " << line_ << ".";
+      ss << "IO Exception: " << description << ".";
       e_what_ = ss.str();
   }
   virtual ~IOException() throw() {}

--- a/src/impl/list_ports/list_ports_linux.cc
+++ b/src/impl/list_ports/list_ports_linux.cc
@@ -285,9 +285,11 @@ serial::list_ports()
     vector<string> search_globs;
     
     // This broad pattern yields most devices, such as
-    // /dev/ttyUSB0, /dev/ttyS1, /dev/ttyACM2, /dev/ttyTHS3, /dev/ttyMXUSB4 etc.
+    // /dev/ttyUSB0, /dev/ttyACM2, /dev/ttyTHS3, /dev/ttyMXUSB4, /dev/ttyS10 etc.
     search_globs.push_back("/dev/tty[A-Za-z][A-Za-z0-9]*[0-9]");
-    //Then there are the serial devices with a more unusual naming pattern
+    // but it fails for the simplest /dev/ttyS<ONE digit> devices, so we add them explicitly
+    search_globs.push_back("/dev/ttyS[0-9]");
+    // Then there are the serial devices with more unusual naming pattern:
     // /dev/tty.usbmodem1234, /dev/cu.usb etc.
     search_globs.push_back("/dev/tty.*");
     search_globs.push_back("/dev/cu.*");

--- a/src/impl/list_ports/list_ports_linux.cc
+++ b/src/impl/list_ports/list_ports_linux.cc
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdarg>
 #include <cstdlib>
+#include <algorithm>
 
 #include <glob.h>
 #include <sys/types.h>
@@ -43,6 +44,7 @@ static vector<string> get_sysfs_info(const string& device_path);
 static string read_line(const string& file);
 static string usb_sysfs_hw_string(const string& sysfs_path);
 static string format(const char* format, ...);
+static string to_lower(const string& in);
 
 vector<string>
 glob(const vector<string>& patterns)
@@ -55,7 +57,6 @@ glob(const vector<string>& patterns)
     glob_t glob_results;
 
     glob(patterns[0].c_str(), 0, NULL, &glob_results);
-
     vector<string>::const_iterator iter = patterns.begin();
 
     while(++iter != patterns.end())
@@ -69,7 +70,6 @@ glob(const vector<string>& patterns)
     }
 
     globfree(&glob_results);
-
     return paths_found;
 }
 
@@ -112,13 +112,11 @@ string
 realpath(const string& path)
 {
     char* real_path = realpath(path.c_str(), NULL);
-
     string result;
 
     if(real_path != NULL)
     {
         result = real_path;
-
         free(real_path);
     }
 
@@ -129,13 +127,9 @@ string
 usb_sysfs_friendly_name(const string& sys_usb_path)
 {
     unsigned int device_number = 0;
-
     istringstream( read_line(sys_usb_path + "/devnum") ) >> device_number;
-
     string manufacturer = read_line( sys_usb_path + "/manufacturer" );
-
     string product = read_line( sys_usb_path + "/product" );
-
     string serial = read_line( sys_usb_path + "/serial" );
 
     if( manufacturer.empty() && product.empty() && serial.empty() )
@@ -148,24 +142,24 @@ vector<string>
 get_sysfs_info(const string& device_path)
 {
     string device_name = basename( device_path );
-
     string friendly_name;
-
     string hardware_id;
-
     string sys_device_path = format( "/sys/class/tty/%s/device", device_name.c_str() );
 
-    if( device_name.compare(0,6,"ttyUSB") == 0 )
+    //if( device_name.compare(0,6,"ttyUSB") == 0 )
+    // Rewriting check to be more general. Any presence of "USB" in the device name
+    // will do.
+    if (device_name.find("USB") != string::npos)
     {
         sys_device_path = dirname( dirname( realpath( sys_device_path ) ) );
 
         if( path_exists( sys_device_path ) )
         {
             friendly_name = usb_sysfs_friendly_name( sys_device_path );
-
             hardware_id = usb_sysfs_hw_string( sys_device_path );
         }
     }
+    //Catch the generic USB driver class "ACM"
     else if( device_name.compare(0,6,"ttyACM") == 0 )
     {
         sys_device_path = dirname( realpath( sys_device_path ) );
@@ -173,23 +167,23 @@ get_sysfs_info(const string& device_path)
         if( path_exists( sys_device_path ) )
         {
             friendly_name = usb_sysfs_friendly_name( sys_device_path );
-
             hardware_id = usb_sysfs_hw_string( sys_device_path );
         }
     }
+    // Final attempt is to read the ID string of a PCI device
     else
     {
         // Try to read ID string of PCI device
-
         string sys_id_path = sys_device_path + "/id";
 
         if( path_exists( sys_id_path ) )
             hardware_id = read_line( sys_id_path );
     }
 
+    // In case any of the above failed, fall back to the device name (by path)
     if( friendly_name.empty() )
         friendly_name = device_name;
-
+    // And give up on the hardware ID
     if( hardware_id.empty() )
         hardware_id = "n/a";
 
@@ -204,7 +198,6 @@ string
 read_line(const string& file)
 {
     ifstream ifs(file.c_str(), ifstream::in);
-
     string line;
 
     if(ifs)
@@ -219,24 +212,19 @@ string
 format(const char* format, ...)
 {
     va_list ap;
-
     size_t buffer_size_bytes = 256;
-
     string result;
-
     char* buffer = (char*)malloc(buffer_size_bytes);
 
     if( buffer == NULL )
         return result;
 
     bool done = false;
-
     unsigned int loop_count = 0;
 
     while(!done)
     {
         va_start(ap, format);
-
         int return_value = vsnprintf(buffer, buffer_size_bytes, format, ap);
 
         if( return_value < 0 )
@@ -246,9 +234,7 @@ format(const char* format, ...)
         else if( static_cast<size_t>(return_value) >= buffer_size_bytes )
         {
             // Realloc and try again.
-
             buffer_size_bytes = return_value + 1;
-
             char* new_buffer_ptr = (char*)realloc(buffer, buffer_size_bytes);
 
             if( new_buffer_ptr == NULL )
@@ -273,7 +259,6 @@ format(const char* format, ...)
     }
 
     free(buffer);
-
     return result;
 }
 
@@ -288,7 +273,6 @@ usb_sysfs_hw_string(const string& sysfs_path)
     }
 
     string vid = read_line( sysfs_path + "/idVendor" );
-
     string pid = read_line( sysfs_path + "/idProduct" );
 
     return format("USB VID:PID=%s:%s %s", vid.c_str(), pid.c_str(), serial_number.c_str() );
@@ -298,27 +282,46 @@ vector<PortInfo>
 serial::list_ports()
 {
     vector<PortInfo> results;
-
     vector<string> search_globs;
-    search_globs.push_back("/dev/ttyACM*");
-    search_globs.push_back("/dev/ttyS*");
-    search_globs.push_back("/dev/ttyUSB*");
+    
+    // This broad pattern yields most devices, such as
+    // /dev/ttyUSB0, /dev/ttyS1, /dev/ttyACM2, /dev/ttyTHS3, /dev/ttyMXUSB4 etc.
+    search_globs.push_back("/dev/tty[A-Za-z][A-Za-z0-9]*[0-9]");
+    //Then there are the serial devices with a more unusual naming pattern
+    // /dev/tty.usbmodem1234, /dev/cu.usb etc.
     search_globs.push_back("/dev/tty.*");
     search_globs.push_back("/dev/cu.*");
+    // Finally, the standard name convention for bluetooth devices
     search_globs.push_back("/dev/rfcomm*");
 
     vector<string> devices_found = glob( search_globs );
-
     vector<string>::iterator iter = devices_found.begin();
 
     while( iter != devices_found.end() )
     {
         string device = *iter++;
 
+        // As the device filter is broadened, we need to make some basic
+        // checks on non-obvious devices names.
+        if (device.compare(5,9,"ttyS") != 0                     // Do not check /dev/ttyS*
+            && to_lower(device).find("usb") == string::npos     // Do not check and device name containing "usb/USB"
+            && to_lower(device).find("acm") == string::npos)    // Do not check and device name containing "acm/ACM"
+        {
+            // Strip all but the last part of the device path (e.g. /dev/ttyTHS2 -> ttyTHS2)
+            string device_name = device.substr(device.find_last_of("/") + 1);
+            // Look up the system device path for this device name
+            string real_sys_device_path = realpath(format("/sys/class/tty/%s/device", device_name.c_str()));
+            if (to_lower(real_sys_device_path).find("serial") == string::npos)
+            {
+                // If this non-obvious device name does not point to a serial device, skip it
+                // We are expecting the device path to contain the string "serial" at some point
+                // for serial devices
+                continue;
+            }
+        }
+
         vector<string> sysfs_info = get_sysfs_info( device );
-
         string friendly_name = sysfs_info[0];
-
         string hardware_id = sysfs_info[1];
 
         PortInfo device_entry;
@@ -327,10 +330,16 @@ serial::list_ports()
         device_entry.hardware_id = hardware_id;
 
         results.push_back( device_entry );
-
     }
 
     return results;
+}
+
+string to_lower(const string& in)
+{
+    string out = in;
+    std::transform(out.begin(), out.end(), out.begin(), ::tolower);
+    return out;
 }
 
 #endif // defined(__linux__)


### PR DESCRIPTION
list_ports( ) on Linux had some shortcomings in the way it assumed serial port paths. These are addressed to catch more potential ports.

The source file + line number output in thrown error messages are removed.

In addition, changes are made to documentation, and a cmake file for the example project is added (invoked from the root cmake file).